### PR TITLE
Switch to non-deprecated insert_cols

### DIFF
--- a/src/r2sundials.cpp
+++ b/src/r2sundials.cpp
@@ -566,7 +566,7 @@ const int Ns=0, NumericVector psens=NumericVector::create(), NumericVector sens_
       if (retevent == R2SUNDIALS_EVENT_IGNORE) {
         ; // do nothing
       } else {
-        mroots.insert_cols(mroots.n_cols, 1, false);
+        mroots.insert_cols(mroots.n_cols, 1);
         mroots.col(mroots.n_cols-1)[0]=t;
         mroots.col(mroots.n_cols-1).subvec(1, nroot)=conv_to<vec>::from(rootsfound);
         // insert this time point and current state
@@ -576,7 +576,7 @@ const int Ns=0, NumericVector psens=NumericVector::create(), NumericVector sens_
           res.insert_cols(iout+insroot, yvec);
           if (Ns > 0) {
             CVodeGetSens(cvode_mem, &t, yS);
-            asens.insert_cols(iout+insroot, 1, false);
+            asens.insert_cols(iout+insroot, 1);
             for (int is=0; is < Ns; is++)
               asens.slice(is).col(iout+insroot)=ySv[is];
           }
@@ -589,7 +589,7 @@ const int Ns=0, NumericVector psens=NumericVector::create(), NumericVector sens_
           res.insert_cols(iout+insroot, ynew);
           if (Ns > 0) {
             // reinit yS to ySv
-            asens.insert_cols(iout+insroot, 1, false);
+            asens.insert_cols(iout+insroot, 1);
             for (int is=0; is < Ns; is++) {
               asens.slice(is).col(iout+insroot)=ySv[is];
             }


### PR DESCRIPTION
For reasons related to issues discussed in https://github.com/RcppCore/RcppArmadillo/issues/391 and https://github.com/RcppCore/RcppArmadillo/issues/402, RcppArmadillo is building with deprecation warnings suppressed.  I plan to change that ... and when I do r2sundials with create three warnings from your use of a three-argument form of `insert_cols` that is now deprecated.  This is simple: use the two-argument form.  I tested the change and R CMD check still passes.

It would be great if you could update r2sundials in the next few weeks. I plan to update RcppArmadillo in about a month and then stop suppressing warnings.